### PR TITLE
refactor: use `tweetnacl` directly

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,15 +1,19 @@
-import { sign_detached_verify } from "https://deno.land/x/tweetnacl_deno_fix@1.1.2/src/sign.ts"
-import Buffer from "https://deno.land/std@0.76.0/node/buffer.ts";
+import nacl from "https://cdn.skypack.dev/tweetnacl@v1.0.3?dts";
 
-export const verifySignature = async (
+export const verifySignature = (
     publicKey: string,
     signature: string,
     timestamp: string,
     rawBody: string
-): Promise<boolean> => {
-    return sign_detached_verify(
-        Buffer.from(timestamp + rawBody),
-        Buffer.from(signature, "hex"),
-        Buffer.from(publicKey, "hex")
+): boolean => {
+    return nacl.sign.detached.verify(
+      new TextEncoder().encode(timestamp + rawBody),
+      hexToUint8Array(signature),
+      hexToUint8Array(publicKey),
     );
 };
+
+/** Converts a hexadecimal string to Uint8Array. */
+function hexToUint8Array(hex: string) {
+  return new Uint8Array(hex.match(/.{1,2}/g)!.map((val) => parseInt(val, 16)));
+}


### PR DESCRIPTION
Follows Deno Deploy example at https://deno.com/deploy/docs/tutorial-discord-slash

Uses official `tweetnacl` instead.